### PR TITLE
Caches static resources

### DIFF
--- a/nix-support-dev/lainchan.nix
+++ b/nix-support-dev/lainchan.nix
@@ -95,6 +95,14 @@ in
     virtualHosts.${domain} = {
       serverAliases = [ "dev.leftypol.org" "www.leftypol.org" ];
       locations = {
+        # Long cache all media items which are unlikely to change.
+        "~* \.(?:jpg|jpeg|png|gif|ico|css|js|mp4|mp3|webm|pdf|bmp|zip|epub|woff|woff2)$" = {
+          root = dataDir;
+          extraConfig = ''
+            expires 1d;
+          '';
+        };
+
         "~ \.php$" = {
           root = dataDir;
           extraConfig = ''

--- a/nix-support-production/lainchan.nix
+++ b/nix-support-production/lainchan.nix
@@ -120,6 +120,14 @@ in
       #addSSL = true;
 
       locations = {
+        # Long cache all media items which are unlikely to change.
+        "~* \.(?:jpg|jpeg|png|gif|ico|css|js|mp4|mp3|webm|pdf|bmp|zip|epub|woff|woff2)$" = {
+          root = dataDir;
+          extraConfig = ''
+            expires 1d;
+          '';
+        };
+
         "~ \.php$" = {
           root = dataDir;
           extraConfig = ''


### PR DESCRIPTION
 namely: jpg|jpeg|png|gif|ico|css|js|mp4|mp3|webm|pdf|bmp|zip|epub|woff|woff2. 

HTML pages get updated by php scripts, so they can't be cached with the 30m TTL provided by Cloudflare's free tier as far as I've understood it.